### PR TITLE
Add support for Windows Bash (MSYS bash)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,18 +3,8 @@ const { join } = require('path');
 const { spawnSync } = require('child_process');
 const tmp = require('tmp');
 
-function windows(string) {
-	const file = join(__dirname, '../helpers/pager.ps1');
-	spawnSync('powershell', ['-File', file, string], { stdio: 'inherit' });
-}
-
 module.exports = (string, options = '-R') => {
 	return new Promise((resolve, reject) => {
-		if (process.platform === 'win32') {
-			windows(string);
-			return resolve();
-		}
-
 		tmp.file((err, path, fd, cleanupCb) => {
 			if (err) {
 				return reject(err);


### PR DESCRIPTION
I tried to use one cool little util: [`mdless`](https://github.com/MikeyBurkman/mdless). The lib kinda works in `cmd.exe`, - it seems... But on Windows there's one de-facto standard: [Git SCM](https://git-scm.com/downloads). With it, there comes console wrapper called `bash.exe`, as a replacement to `cmd.exe`, - essentially, it has all the little tools like `less`, etc., mimicking Linux environment.

But there come some issues with `node-pager` on Windows currently when I use this util:

![image](https://user-images.githubusercontent.com/13215662/137493914-235d431c-2b45-48e9-924b-de2feecbdf54.png)

- It doesn't display emoji
- Tables are poorly displayed, too
- etc etc

All because of this powershell hack in the code. But if I remove it, as shown in the PR, - it now works perfectly!

![image](https://user-images.githubusercontent.com/13215662/137493779-bee10cf8-07d2-4f73-a861-146fb87ca626.png)
